### PR TITLE
Match document_path againts subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 9.2.1 - 2022-09-29
+
+- Using a CSV file as input to `datasets create-documents` will now try to locate the document file specified by
+`document-path-column` in all sub-directories, e.g. if `document_path=foo/bar/baz.pdf` it will first see if
+`foo/bar/baz.pdf` points to an existing and valid file type, then it will check if `bar/baz.pdf` points to an existing
+and valid file type and so forth.
+- Fixed output bug in `datasets get-documents`. Now only counts number of documents from the dataset you are
+downloading, not the number of documents in the outdir_dir
+
 ## Version 9.2.0 - 2022-09-28
 
 - Added `--image-url` to `transitions update`

--- a/lascli/parser/datasets.py
+++ b/lascli/parser/datasets.py
@@ -174,7 +174,7 @@ def _documents_from_dir(src_dir, accepted_document_types, ground_truth_encoding)
                 if ground_truth_path:
                     print(f'Ground truth file for {name} already found (Old: {ground_truth_path} New: {path})')
                 ground_truth_path = path
-            elif _is_acceptable_file_type(document_path, accepted_document_types):
+            elif _is_acceptable_file_type(path, accepted_document_types):
                 if document_path:
                     print(f'Document file for {name} already found (Old: {document_path} New: {path})')
                 document_path = path

--- a/lascli/parser/datasets.py
+++ b/lascli/parser/datasets.py
@@ -199,7 +199,8 @@ def read_csv(path, document_path_column, accepted_document_types, delimiter, enc
     with path.open('r') as csv_file:
         reader = csv.DictReader(csv_file, delimiter=delimiter)
         for row in reader:
-            if document_path := find_document_path(Path(row.pop(document_path_column)), accepted_document_types):
+            document_path = find_document_path(Path(row.pop(document_path_column)), accepted_document_types)
+            if document_path:
                 yield document_path, [{'label': k, 'value': v} for k, v in row.items()]
             else:
                 print(f'Document {document_path} is not one of the accepted document types {accepted_document_types}')

--- a/lascli/parser/datasets.py
+++ b/lascli/parser/datasets.py
@@ -210,7 +210,7 @@ def _documents_from_file(src_file, document_path_column, accepted_document_types
 
 @contextmanager
 def cache(dataset_id, input_path, no_cache):
-    cache_file = _cache_dir() / hashlib.md5((dataset_id + str(input_path)).encode()).hexdigest()
+    cache_file = _cache_dir() / hashlib.md5(dataset_id.encode()).hexdigest()
     already_uploaded = defaultdict(dict)
 
     if cache_file.exists():


### PR DESCRIPTION
- Cache only by dataset ID
- Fix get-documents, fuzzy path matching in created-documents

If you have documents in a directory called `foobarbaz` relative to pwd it will find all rows in below CSV when running `datasets create-documents`
```csv
document_path,total_amount
foobarbaz/a.pdf,100.00
bar/foobarbaz/b.pdf,200.50
/bar/foobarbaz/c.pdf,10.88
s3://barbucket/bar/bar/foobarbaz/d.pdf,11.22
```
